### PR TITLE
fix argument error

### DIFF
--- a/lib/record_with_operator/recorder.rb
+++ b/lib/record_with_operator/recorder.rb
@@ -19,7 +19,7 @@ module RecordWithOperator
     def update_deleter
       return if frozen?
       return unless operator
-      self.class.update_all("#{RecordWithOperator.deleter_column} = #{operator.id}", ["#{self.class.primary_key} = ?", id])
+      self.class.update_all("#{RecordWithOperator.deleter_column} = #{operator.id}")
       send("#{RecordWithOperator.deleter_column}=", operator.id)
     end
 


### PR DESCRIPTION
on rails 5.0.2 i got an argument error exception when RecordWithOperator::Recorder#update_deleter is called. I'm not sure that my fix is good but i do not have anymore the exception after this commit.